### PR TITLE
Use AutoReqProv instead of AutoReq

### DIFF
--- a/templates/spec.mustache
+++ b/templates/spec.mustache
@@ -17,7 +17,7 @@ Requires: nodejs
 Requires: {{.}}
 {{/requires}}
 BuildRequires: nodejs
-AutoReq: no
+AutoReqProv: no
 
 %description
 {{description}}

--- a/test/fixtures/my-cool-api-7.spec
+++ b/test/fixtures/my-cool-api-7.spec
@@ -14,7 +14,7 @@ Source: %{name}.tar.gz
 BuildRoot: %{buildroot}
 Requires: nodejs
 BuildRequires: nodejs
-AutoReq: no
+AutoReqProv: no
 
 %description
 My Cool API

--- a/test/fixtures/my-cool-api-with-diff-licence.spec
+++ b/test/fixtures/my-cool-api-with-diff-licence.spec
@@ -16,7 +16,7 @@ Requires: nodejs
 Requires: vim
 Requires: screen
 BuildRequires: nodejs
-AutoReq: no
+AutoReqProv: no
 
 %description
 My Cool API

--- a/test/fixtures/my-cool-api-with-executable.spec
+++ b/test/fixtures/my-cool-api-with-executable.spec
@@ -14,7 +14,7 @@ Source: %{name}.tar.gz
 BuildRoot: %{buildroot}
 Requires: nodejs
 BuildRequires: nodejs
-AutoReq: no
+AutoReqProv: no
 
 %description
 My Cool API

--- a/test/fixtures/my-cool-api-with-post.spec
+++ b/test/fixtures/my-cool-api-with-post.spec
@@ -14,7 +14,7 @@ Source: %{name}.tar.gz
 BuildRoot: %{buildroot}
 Requires: nodejs
 BuildRequires: nodejs
-AutoReq: no
+AutoReqProv: no
 
 %description
 My Cool API

--- a/test/fixtures/my-cool-api-with-requires.spec
+++ b/test/fixtures/my-cool-api-with-requires.spec
@@ -16,7 +16,7 @@ Requires: nodejs
 Requires: vim
 Requires: screen
 BuildRequires: nodejs
-AutoReq: no
+AutoReqProv: no
 
 %description
 My Cool API

--- a/test/fixtures/my-cool-api.spec
+++ b/test/fixtures/my-cool-api.spec
@@ -14,7 +14,7 @@ Source: %{name}.tar.gz
 BuildRoot: %{buildroot}
 Requires: nodejs
 BuildRequires: nodejs
-AutoReq: no
+AutoReqProv: no
 
 %description
 My Cool API

--- a/test/fixtures/my-super-long-long-long-long-cat-api.spec
+++ b/test/fixtures/my-super-long-long-long-long-cat-api.spec
@@ -14,7 +14,7 @@ Source: %{name}.tar.gz
 BuildRoot: %{buildroot}
 Requires: nodejs
 BuildRequires: nodejs
-AutoReq: no
+AutoReqProv: no
 
 %description
 My Super Long Long Long Long Cat API


### PR DESCRIPTION
* Fixes #10
* Will prevent RPM from automatically creating `Provides:`
* http://www.rpm.org/max-rpm/s1-rpm-specref-preamble.html#S3-RPM-SPECREF-AUTOREQPROV