### PR TITLE
Automatically prune development dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,15 +111,18 @@ You can then run `npm run spec` to generate your spec file in an environment whe
 
 ### Pruning dependencies
 
-To minimise the final RPM size, it's a good idea to [prune](https://docs.npmjs.com/cli/prune) your development dependencies so that they're not shipped with your production code.
+To minimise the final RPM size, your development dependencies (dependencies added with the --save-dev flag) are automatically [pruned](https://docs.npmjs.com/cli/prune) so that they're not shipped with your production code.
 
-You can do this before you run speculate:
+If for some reason you need to package your dev dependencies with your production code you can explicity tell speculate not to prune by adding the following to your package.json:
 
-```bash
-npm install
-npm test
-npm prune --production
-speculate
+```json
+{
+  "spec": {
+    "prune": false  
+  }
+}
+```
+
 # build RPM
 ```
 

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -37,13 +37,20 @@ function getPostInstallCommands(pkg) {
   return _.get(pkg, 'spec.post', []);
 }
 
+function shouldPrune(pkg) {
+  var pkgPrune = _.get(pkg, 'spec.prune');
+  // Only return false when spec.prune is explicity false.
+  return !(pkgPrune === false);
+}
+
 module.exports = function (pkg, release) {
   var serviceProperties = _.assign({
       release: getReleaseNumber(release),
       requires: getRequiredPackages(pkg),
       postInstallCommands: getPostInstallCommands(pkg),
       version: pkg.version,
-      license: pkg.license
+      license: pkg.license,
+      prune: shouldPrune(pkg)
     },
     getExecutableFiles(pkg),
     getServiceProperties(pkg)

--- a/templates/spec.mustache
+++ b/templates/spec.mustache
@@ -26,6 +26,9 @@ AutoReq: no
 %setup -q -c -n %{name}
 
 %build
+{{#prune}}
+npm prune --production
+{{/prune}}
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-no-prune.json
+++ b/test/fixtures/my-cool-api-no-prune.json
@@ -1,0 +1,14 @@
+{
+  "name": "my-cool-api",
+  "version": "1.1.1",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "description": "My Cool API",
+  "main": "index.js",
+  "author": "bob@example.com",
+  "license": "MIT",
+  "spec": {
+    "prune": false
+  }
+}

--- a/test/fixtures/my-cool-api-no-prune.spec
+++ b/test/fixtures/my-cool-api-no-prune.spec
@@ -1,6 +1,6 @@
 %define name my-cool-api
 %define version 1.1.1
-%define release 7
+%define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
 
 Name: %{name}
@@ -23,7 +23,6 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-with-diff-licence.spec
+++ b/test/fixtures/my-cool-api-with-diff-licence.spec
@@ -25,6 +25,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
+npm prune --production
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-with-executable.spec
+++ b/test/fixtures/my-cool-api-with-executable.spec
@@ -23,6 +23,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
+npm prune --production
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-with-post.spec
+++ b/test/fixtures/my-cool-api-with-post.spec
@@ -23,6 +23,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
+npm prune --production
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-with-requires.spec
+++ b/test/fixtures/my-cool-api-with-requires.spec
@@ -25,6 +25,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
+npm prune --production
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api.spec
+++ b/test/fixtures/my-cool-api.spec
@@ -23,6 +23,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
+npm prune --production
 npm rebuild
 
 %pre

--- a/test/fixtures/my-super-long-long-long-long-cat-api.spec
+++ b/test/fixtures/my-super-long-long-long-long-cat-api.spec
@@ -23,6 +23,7 @@ My Super Long Long Long Long Cat API
 %setup -q -c -n %{name}
 
 %build
+npm prune --production
 npm rebuild
 
 %pre

--- a/test/spec.js
+++ b/test/spec.js
@@ -19,6 +19,14 @@ describe('spec', function () {
     assert.equal(spec, expected);
   });
 
+  it('removes the prune step when specified', function () {
+    var pkg = require('./fixtures/my-cool-api-no-prune');
+    var expected = loadFixture('my-cool-api-no-prune.spec');
+    var spec = createSpecFile(pkg);
+
+    assert.equal(spec, expected);
+  });
+
   it('sets the release number when specified', function () {
     var releaseNumber = 7;
     var pkg = require('./fixtures/my-cool-api');


### PR DESCRIPTION
This PR adds `npm prune --production` as a build step in the spec file. 

This feature can be explicitly turned off, by setting the prune flag to `false`.

This PR closes #9. 