### PR TITLE
Add npm to BuildRequires

### DIFF
--- a/templates/spec.mustache
+++ b/templates/spec.mustache
@@ -17,6 +17,7 @@ Requires: nodejs
 Requires: {{.}}
 {{/requires}}
 BuildRequires: nodejs
+BuildRequires: npm
 AutoReqProv: no
 
 %description

--- a/test/fixtures/my-cool-api-7.spec
+++ b/test/fixtures/my-cool-api-7.spec
@@ -14,6 +14,7 @@ Source: %{name}.tar.gz
 BuildRoot: %{buildroot}
 Requires: nodejs
 BuildRequires: nodejs
+BuildRequires: npm
 AutoReqProv: no
 
 %description

--- a/test/fixtures/my-cool-api-no-prune.spec
+++ b/test/fixtures/my-cool-api-no-prune.spec
@@ -14,6 +14,7 @@ Source: %{name}.tar.gz
 BuildRoot: %{buildroot}
 Requires: nodejs
 BuildRequires: nodejs
+BuildRequires: npm
 AutoReqProv: no
 
 %description

--- a/test/fixtures/my-cool-api-with-diff-licence.spec
+++ b/test/fixtures/my-cool-api-with-diff-licence.spec
@@ -16,6 +16,7 @@ Requires: nodejs
 Requires: vim
 Requires: screen
 BuildRequires: nodejs
+BuildRequires: npm
 AutoReqProv: no
 
 %description

--- a/test/fixtures/my-cool-api-with-executable.spec
+++ b/test/fixtures/my-cool-api-with-executable.spec
@@ -14,6 +14,7 @@ Source: %{name}.tar.gz
 BuildRoot: %{buildroot}
 Requires: nodejs
 BuildRequires: nodejs
+BuildRequires: npm
 AutoReqProv: no
 
 %description

--- a/test/fixtures/my-cool-api-with-post.spec
+++ b/test/fixtures/my-cool-api-with-post.spec
@@ -14,6 +14,7 @@ Source: %{name}.tar.gz
 BuildRoot: %{buildroot}
 Requires: nodejs
 BuildRequires: nodejs
+BuildRequires: npm
 AutoReqProv: no
 
 %description

--- a/test/fixtures/my-cool-api-with-requires.spec
+++ b/test/fixtures/my-cool-api-with-requires.spec
@@ -16,6 +16,7 @@ Requires: nodejs
 Requires: vim
 Requires: screen
 BuildRequires: nodejs
+BuildRequires: npm
 AutoReqProv: no
 
 %description

--- a/test/fixtures/my-cool-api.spec
+++ b/test/fixtures/my-cool-api.spec
@@ -14,6 +14,7 @@ Source: %{name}.tar.gz
 BuildRoot: %{buildroot}
 Requires: nodejs
 BuildRequires: nodejs
+BuildRequires: npm
 AutoReqProv: no
 
 %description

--- a/test/fixtures/my-super-long-long-long-long-cat-api.spec
+++ b/test/fixtures/my-super-long-long-long-long-cat-api.spec
@@ -14,6 +14,7 @@ Source: %{name}.tar.gz
 BuildRoot: %{buildroot}
 Requires: nodejs
 BuildRequires: nodejs
+BuildRequires: npm
 AutoReqProv: no
 
 %description


### PR DESCRIPTION
* npm and node were packaged separately for Node 0.10
* We use `npm rebuild` in our build step so we need to require `npm`