### PR TITLE
Added support for specifying service options

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,21 @@ If you need to specify environment variables during startup (NODE_ENV for exampl
 }
 ```
 
+### Service Options
+
+If you need to set specific [systemd service options](https://www.freedesktop.org/software/systemd/man/systemd.exec.html) - in the  `[Service]` section of the .service file, you can specify these using the spec.service-options property:
+
+```json
+{
+  "spec": {
+    "service-options": {
+      "CPUSchedulingPriority": 50,
+      "LimitNOFILE": 10000
+    }
+  }
+}
+```
+
 ### Release Number
 
 By default speculate will set the RPM release number to 1, if you want to override this you can do so by using the `--release` flag:

--- a/lib/serviceProperties.js
+++ b/lib/serviceProperties.js
@@ -8,11 +8,19 @@ function getEnvironment(pkg) {
   });
 }
 
+function getServiceOptions(pkg) {
+  var serviceOptions = _.get(pkg, 'spec.service-options', {});
+  return Object.keys(serviceOptions).map(function(key) {
+    return { key: key, value: serviceOptions[key]};
+  });
+}
+
 module.exports = function (pkg) {
   return {
     name: pkg.name,
     username: truncate(pkg.name),
     description: pkg.description,
-    environment: getEnvironment(pkg)
+    environment: getEnvironment(pkg),
+    serviceOptions: getServiceOptions(pkg)
   };
 };

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -14,6 +14,9 @@ Group={{username}}
 {{#environment}}
 Environment={{key}}={{value}}
 {{/environment}}
+{{#serviceOptions}}
+{{key}}={{value}}
+{{/serviceOptions}}
 
 [Install]
 WantedBy=multi-user.target

--- a/test/fixtures/my-cool-api-with-service-options.json
+++ b/test/fixtures/my-cool-api-with-service-options.json
@@ -1,0 +1,17 @@
+{
+  "name": "my-cool-api",
+  "version": "1.1.1",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "description": "My Cool API",
+  "main": "index.js",
+  "author": "bob@example.com",
+  "license": "MIT",
+  "spec": {
+    "service-options": {
+      "CPUSchedulingPriority": 50,
+      "LimitNOFILE": 10000
+    }
+  }
+}

--- a/test/fixtures/my-cool-api-with-service-options.service
+++ b/test/fixtures/my-cool-api-with-service-options.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=My Cool API
+After=network.target nss-lookup.target
+
+[Service]
+ExecStart=/usr/bin/npm start
+WorkingDirectory=/usr/lib/my-cool-api
+Restart=always
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=my-cool-api
+User=my-cool-api
+Group=my-cool-api
+CPUSchedulingPriority=50
+LimitNOFILE=10000
+
+[Install]
+WantedBy=multi-user.target

--- a/test/service.js
+++ b/test/service.js
@@ -26,4 +26,12 @@ describe('service', function () {
 
     assert.equal(service, expected);
   });
+
+  it('includes service options from the spec.service-options property in package.json', function() {
+    var pkg = require('./fixtures/my-cool-api-with-service-options');
+    var expected = loadFixture('my-cool-api-with-service-options.service');
+    var service = createServiceFile(pkg);
+
+    assert.equal(service, expected);
+  });
 });


### PR DESCRIPTION
This small change gives greater flexibility in specifying the environment that node.js process runs in:

https://www.freedesktop.org/software/systemd/man/systemd.exec.html
