### PR TITLE
Include hidden files in output directory

### DIFF
--- a/templates/spec.mustache
+++ b/templates/spec.mustache
@@ -40,7 +40,7 @@ getent passwd {{username}} >/dev/null || useradd -r -g {{username}} -G {{usernam
 
 %install
 mkdir -p %{buildroot}/usr/lib/{{name}}
-cp -r ./* %{buildroot}/usr/lib/{{name}}
+cp -r ./ %{buildroot}/usr/lib/{{name}}
 mkdir -p %{buildroot}/var/log/{{name}}
 
 %post

--- a/test/fixtures/my-cool-api-7.spec
+++ b/test/fixtures/my-cool-api-7.spec
@@ -32,7 +32,7 @@ getent passwd my-cool-api >/dev/null || useradd -r -g my-cool-api -G my-cool-api
 
 %install
 mkdir -p %{buildroot}/usr/lib/my-cool-api
-cp -r ./* %{buildroot}/usr/lib/my-cool-api
+cp -r ./ %{buildroot}/usr/lib/my-cool-api
 mkdir -p %{buildroot}/var/log/my-cool-api
 
 %post

--- a/test/fixtures/my-cool-api-no-prune.spec
+++ b/test/fixtures/my-cool-api-no-prune.spec
@@ -31,7 +31,7 @@ getent passwd my-cool-api >/dev/null || useradd -r -g my-cool-api -G my-cool-api
 
 %install
 mkdir -p %{buildroot}/usr/lib/my-cool-api
-cp -r ./* %{buildroot}/usr/lib/my-cool-api
+cp -r ./ %{buildroot}/usr/lib/my-cool-api
 mkdir -p %{buildroot}/var/log/my-cool-api
 
 %post

--- a/test/fixtures/my-cool-api-with-buildrequires.spec
+++ b/test/fixtures/my-cool-api-with-buildrequires.spec
@@ -33,7 +33,7 @@ getent passwd my-cool-api >/dev/null || useradd -r -g my-cool-api -G my-cool-api
 
 %install
 mkdir -p %{buildroot}/usr/lib/my-cool-api
-cp -r ./* %{buildroot}/usr/lib/my-cool-api
+cp -r ./ %{buildroot}/usr/lib/my-cool-api
 mkdir -p %{buildroot}/var/log/my-cool-api
 
 %post

--- a/test/fixtures/my-cool-api-with-diff-licence.spec
+++ b/test/fixtures/my-cool-api-with-diff-licence.spec
@@ -34,7 +34,7 @@ getent passwd my-cool-api >/dev/null || useradd -r -g my-cool-api -G my-cool-api
 
 %install
 mkdir -p %{buildroot}/usr/lib/my-cool-api
-cp -r ./* %{buildroot}/usr/lib/my-cool-api
+cp -r ./ %{buildroot}/usr/lib/my-cool-api
 mkdir -p %{buildroot}/var/log/my-cool-api
 
 %post

--- a/test/fixtures/my-cool-api-with-executable.spec
+++ b/test/fixtures/my-cool-api-with-executable.spec
@@ -32,7 +32,7 @@ getent passwd my-cool-api >/dev/null || useradd -r -g my-cool-api -G my-cool-api
 
 %install
 mkdir -p %{buildroot}/usr/lib/my-cool-api
-cp -r ./* %{buildroot}/usr/lib/my-cool-api
+cp -r ./ %{buildroot}/usr/lib/my-cool-api
 mkdir -p %{buildroot}/var/log/my-cool-api
 
 %post

--- a/test/fixtures/my-cool-api-with-node-version.spec
+++ b/test/fixtures/my-cool-api-with-node-version.spec
@@ -34,7 +34,7 @@ getent passwd my-cool-api >/dev/null || useradd -r -g my-cool-api -G my-cool-api
 
 %install
 mkdir -p %{buildroot}/usr/lib/my-cool-api
-cp -r ./* %{buildroot}/usr/lib/my-cool-api
+cp -r ./ %{buildroot}/usr/lib/my-cool-api
 mkdir -p %{buildroot}/var/log/my-cool-api
 
 %post

--- a/test/fixtures/my-cool-api-with-post.spec
+++ b/test/fixtures/my-cool-api-with-post.spec
@@ -32,7 +32,7 @@ getent passwd my-cool-api >/dev/null || useradd -r -g my-cool-api -G my-cool-api
 
 %install
 mkdir -p %{buildroot}/usr/lib/my-cool-api
-cp -r ./* %{buildroot}/usr/lib/my-cool-api
+cp -r ./ %{buildroot}/usr/lib/my-cool-api
 mkdir -p %{buildroot}/var/log/my-cool-api
 
 %post

--- a/test/fixtures/my-cool-api-with-requires.spec
+++ b/test/fixtures/my-cool-api-with-requires.spec
@@ -34,7 +34,7 @@ getent passwd my-cool-api >/dev/null || useradd -r -g my-cool-api -G my-cool-api
 
 %install
 mkdir -p %{buildroot}/usr/lib/my-cool-api
-cp -r ./* %{buildroot}/usr/lib/my-cool-api
+cp -r ./ %{buildroot}/usr/lib/my-cool-api
 mkdir -p %{buildroot}/var/log/my-cool-api
 
 %post

--- a/test/fixtures/my-cool-api.spec
+++ b/test/fixtures/my-cool-api.spec
@@ -32,7 +32,7 @@ getent passwd my-cool-api >/dev/null || useradd -r -g my-cool-api -G my-cool-api
 
 %install
 mkdir -p %{buildroot}/usr/lib/my-cool-api
-cp -r ./* %{buildroot}/usr/lib/my-cool-api
+cp -r ./ %{buildroot}/usr/lib/my-cool-api
 mkdir -p %{buildroot}/var/log/my-cool-api
 
 %post

--- a/test/fixtures/my-super-long-long-long-long-cat-api.spec
+++ b/test/fixtures/my-super-long-long-long-long-cat-api.spec
@@ -32,7 +32,7 @@ getent passwd my-super-long-long-long-long-cat >/dev/null || useradd -r -g my-su
 
 %install
 mkdir -p %{buildroot}/usr/lib/my-super-long-long-long-long-cat-api
-cp -r ./* %{buildroot}/usr/lib/my-super-long-long-long-long-cat-api
+cp -r ./ %{buildroot}/usr/lib/my-super-long-long-long-long-cat-api
 mkdir -p %{buildroot}/var/log/my-super-long-long-long-long-cat-api
 
 %post


### PR DESCRIPTION
Previously no hidden files were copied from the .tar file to the application directory.
This is important in some node configurations, such as using babel at runtime (.babelrc) or dotenv (.env).

Unfortunately this goes further away from https://github.com/bbc/speculate/issues/8 by introducing _more_ file copies.