### PR TITLE
Update RPM version range documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,7 +150,16 @@ If you're using multiple node repositories or a repository with multiple version
   }
 }
 ```
-The `nodeVersion` property must conform to the [RPM version syntax](http://www.rpm.org/max-rpm/s1-rpm-depend-manual-dependencies.html#S3-RPM-DEPEND-VERSION-REQUIREMENTS)
+The `nodeVersion` property must conform to the [RPM version syntax](http://rpm.org/user_doc/dependencies.html#requires). Take particular note of the `epoch` (`[epoch:]version[-release]`) as a range without an epoch may not result in the desired dependency:
+
+```shell
+"nodeVersion": "< 5.0.0"
+---
+Available Packages
+nodejs.x86_64                             6.2.2-1nodesource.el7.centos          nodesource # <- matches as no epoch specified
+nodejs.x86_64                             1:6.3.0-1nodesource.el7.centos        nodesource
+nodejs.x86_64                             2:6.11.0-1nodesource.el7.centos       nodesource # <- Latest but epoch of '2'
+```
 
 ### Directory Structure
 


### PR DESCRIPTION
The previous link was dead and seems to be essentially archived (it still exists on ftp.).

Switched to a [link from the new website](http://rpm.org/user_doc/dependencies.html#requires) with the same info, added specific help documentation regarding epoch as I got stung by this when naively specifying `< 7.0.0` for `nodeVersion`.