### PR TITLE
Do not escape %post commands

### DIFF
--- a/templates/spec.mustache
+++ b/templates/spec.mustache
@@ -46,7 +46,7 @@ mkdir -p %{buildroot}/var/log/{{name}}
 %post
 systemctl enable /usr/lib/{{name}}/{{name}}.service
 {{#postInstallCommands}}
-{{.}}
+{{{.}}}
 {{/postInstallCommands}}
 
 %clean

--- a/test/fixtures/my-cool-api-with-post.json
+++ b/test/fixtures/my-cool-api-with-post.json
@@ -10,7 +10,8 @@
   "license": "MIT",
   "spec": {
     "post": [
-      "mv /usr/lib/my-cool-api/rc.local /etc/rc.local"
+      "mv /usr/lib/my-cool-api/rc.local /etc/rc.local",
+      "find /etc/bake-scripts/application -maxdepth 1 -type f ! \\( -name \"*.pyc\" -or -name '*.pyo' \\) -exec chmod +x {} +"
     ]
   }
 }

--- a/test/fixtures/my-cool-api-with-post.spec
+++ b/test/fixtures/my-cool-api-with-post.spec
@@ -38,6 +38,7 @@ mkdir -p %{buildroot}/var/log/my-cool-api
 %post
 systemctl enable /usr/lib/my-cool-api/my-cool-api.service
 mv /usr/lib/my-cool-api/rc.local /etc/rc.local
+find /etc/bake-scripts/application -maxdepth 1 -type f ! \( -name "*.pyc" -or -name '*.pyo' \) -exec chmod +x {} +
 
 %clean
 rm -rf %{buildroot}


### PR DESCRIPTION
This causes problems with shell scripts using `"` and `'`.
Resolves https://github.com/bbc/speculate/issues/32