### PR TITLE
add ability to define npm rebuild arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,20 @@ If for some reason you need to package your dev dependencies with your productio
 }
 ```
 
+### NPM rebuild arguments
+
+There are cases where you may wish to add parameters to the `npm rebuild` command that is being ran. For example, you may with to specify something like the following:
+
+```json
+{
+  "spec": {
+    "npmRebuildArgs": "--nodedir=/usr/lib"
+  }
+}
+```
+
+which, if you had node-gyp installed would stop it from trying to use the internet from with the mock environment.
+
 ### `npm start` script
 
 The systemd service file that Speculate generates uses the `npm start` script to start your application. Make sure that you've defined this script in your `package.json` file.

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -49,6 +49,10 @@ function shouldPrune(pkg) {
   return _.get(pkg, 'spec.prune', true);
 }
 
+function npmRebuildArgs(pkg) {
+  return _.get(pkg, 'spec.npmRebuildArgs', '');
+}
+
 module.exports = function (pkg, release) {
   var serviceProperties = _.assign({
       release: getReleaseNumber(release),
@@ -58,7 +62,8 @@ module.exports = function (pkg, release) {
       nodeVersion: getNodeVersion(pkg),
       version: pkg.version,
       license: pkg.license,
-      prune: shouldPrune(pkg)
+      prune: shouldPrune(pkg),
+      npmRebuildArgs: npmRebuildArgs(pkg)
     },
     getExecutableFiles(pkg),
     getServiceProperties(pkg)

--- a/templates/spec.mustache
+++ b/templates/spec.mustache
@@ -32,7 +32,7 @@ AutoReqProv: no
 {{#prune}}
 npm prune --production
 {{/prune}}
-npm rebuild
+npm rebuild{{#npmRebuildArgs}} {{npmRebuildArgs}}{{/npmRebuildArgs}}
 
 %pre
 getent group {{username}} >/dev/null || groupadd -r {{username}}

--- a/test/fixtures/my-cool-api-with-npm-rebuild-args.json
+++ b/test/fixtures/my-cool-api-with-npm-rebuild-args.json
@@ -1,0 +1,14 @@
+{
+  "name": "my-cool-api",
+  "version": "1.1.1",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "description": "My Cool API",
+  "main": "index.js",
+  "author": "bob@example.com",
+  "license": "MIT",
+  "spec": {
+    "npmRebuildArgs": "--nodedir=/usr/lib"
+  }
+}

--- a/test/fixtures/my-cool-api-with-npm-rebuild-args.spec
+++ b/test/fixtures/my-cool-api-with-npm-rebuild-args.spec
@@ -1,0 +1,47 @@
+%define name my-cool-api
+%define version 1.1.1
+%define release 1
+%define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
+Name: %{name}
+Version: %{version}
+Release: %{release}
+Summary: my-cool-api
+
+Group: Installation Script
+License: MIT
+Source: %{name}.tar.gz
+BuildRoot: %{buildroot}
+Requires: nodejs
+BuildRequires: nodejs
+AutoReqProv: no
+
+%description
+My Cool API
+
+%prep
+%setup -q -c -n %{name}
+
+%build
+npm prune --production
+npm rebuild --nodedir=/usr/lib
+
+%pre
+getent group my-cool-api >/dev/null || groupadd -r my-cool-api
+getent passwd my-cool-api >/dev/null || useradd -r -g my-cool-api -G my-cool-api -d / -s /sbin/nologin -c "my-cool-api" my-cool-api
+
+%install
+mkdir -p %{buildroot}/usr/lib/my-cool-api
+cp -r ./ %{buildroot}/usr/lib/my-cool-api
+mkdir -p %{buildroot}/var/log/my-cool-api
+
+%post
+systemctl enable /usr/lib/my-cool-api/my-cool-api.service
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(644, my-cool-api, my-cool-api, 755)
+/usr/lib/my-cool-api
+/var/log/my-cool-api

--- a/test/spec.js
+++ b/test/spec.js
@@ -27,6 +27,14 @@ describe('spec', function () {
     assert.equal(spec, expected);
   });
 
+  it('sets npm rebuild args when specified', function () {
+    var pkg = require('./fixtures/my-cool-api-with-npm-rebuild-args.json');
+    var expected = loadFixture('my-cool-api-with-npm-rebuild-args.spec');
+    var spec = createSpecFile(pkg);
+
+    assert.equal(spec, expected);
+  });
+
   it('sets the release number when specified', function () {
     var releaseNumber = 7;
     var pkg = require('./fixtures/my-cool-api');


### PR DESCRIPTION
*Reason for this PR:*

Recently our build agents upgraded to version 1.4.4 of [mock](https://github.com/rpm-software-management/mock) and in version 1.4.1 they added the following:

> Mock previously used chroot technology. Few past releases Mock offered systemd-nspawn which is modern container technology for better isolation. This release use systemd-nspawn as default. If you want to preserve previous behaviour you can use --old-chroot option. NOTE: network is disabled inside container by default now; take a look into site-defaults.cfg for desired options (like rpmbuild_networking).

This, tied with the fact node-gyp will [require the internet](https://github.com/nodejs/node-gyp/issues/812) when doing an `npm rebuild`, we need the ability to add arguments to the `npm rebuild` command.

This PR adds an `npmRebuildArgs` parameter (open to suggestions on this name) which will allow us to do something like what has been added to the README.md:

```json
{
  "spec": {
    "npmRebuildArgs": "--nodedir=/usr/lib"
  }
}
```
