### PR TITLE
Update spec.mustache

### DIFF
--- a/templates/spec.mustache
+++ b/templates/spec.mustache
@@ -14,11 +14,11 @@ Source: %{name}.tar.gz
 BuildRoot: %{buildroot}
 Requires: nodejs{{#nodeVersion}} {{{nodeVersion}}}{{/nodeVersion}}
 {{#requires}}
-Requires: {{.}}
+Requires: {{{.}}}
 {{/requires}}
 BuildRequires: nodejs{{#nodeVersion}} {{{nodeVersion}}}{{/nodeVersion}}
 {{#buildRequires}}
-BuildRequires: {{.}}
+BuildRequires: {{{.}}}
 {{/buildRequires}}
 AutoReqProv: no
 

--- a/test/fixtures/my-cool-api-with-requires-noescape.json
+++ b/test/fixtures/my-cool-api-with-requires-noescape.json
@@ -1,0 +1,19 @@
+{
+  "name": "my-cool-api",
+  "version": "1.1.1",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "description": "My Cool API",
+  "main": "index.js",
+  "author": "bob@example.com",
+  "license": "MIT",
+  "spec": {
+    "requires": [
+      "python >= 2.7.14"
+    ],
+    "buildRequires": [
+      "python >= 2.7.14"
+    ]
+  }
+}

--- a/test/fixtures/my-cool-api-with-requires-noescape.spec
+++ b/test/fixtures/my-cool-api-with-requires-noescape.spec
@@ -1,0 +1,49 @@
+%define name my-cool-api
+%define version 1.1.1
+%define release 1
+%define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
+Name: %{name}
+Version: %{version}
+Release: %{release}
+Summary: my-cool-api
+
+Group: Installation Script
+License: MIT
+Source: %{name}.tar.gz
+BuildRoot: %{buildroot}
+Requires: nodejs
+Requires: python >= 2.7.14
+BuildRequires: nodejs
+BuildRequires: python >= 2.7.14
+AutoReqProv: no
+
+%description
+My Cool API
+
+%prep
+%setup -q -c -n %{name}
+
+%build
+npm prune --production
+npm rebuild
+
+%pre
+getent group my-cool-api >/dev/null || groupadd -r my-cool-api
+getent passwd my-cool-api >/dev/null || useradd -r -g my-cool-api -G my-cool-api -d / -s /sbin/nologin -c "my-cool-api" my-cool-api
+
+%install
+mkdir -p %{buildroot}/usr/lib/my-cool-api
+cp -r ./ %{buildroot}/usr/lib/my-cool-api
+mkdir -p %{buildroot}/var/log/my-cool-api
+
+%post
+systemctl enable /usr/lib/my-cool-api/my-cool-api.service
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(644, my-cool-api, my-cool-api, 755)
+/usr/lib/my-cool-api
+/var/log/my-cool-api

--- a/test/spec.js
+++ b/test/spec.js
@@ -81,4 +81,11 @@ describe('spec', function () {
     var spec = createSpecFile(pkg);
     assert.equal(spec, expected);
   });
+
+  it('avoid escaping the Requires and Buildrequires', function () {
+    var pkg = require('./fixtures/my-cool-api-with-requires-noescape.json');
+    var expected = loadFixture('my-cool-api-with-requires-noescape.spec');
+    var spec = createSpecFile(pkg);
+    assert.equal(spec, expected);
+  });
 });


### PR DESCRIPTION
Added {{{.}}} on Requires and BuildRequires in order to not html escape the content of this lines. This is necessary to specify versions on packages required.

example:

"spec": {
   "requires": [
     "openssl >= 1.0.2"
   ]
 }