### PR TITLE
Updated mocha and codeclimate-test-reporter to address security vulnerabilities

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,6 @@ node_js:
   - "8"
   - "6"
   - "4"
-  - "0.12"
-  - "0.10"
 addons:
   code_climate:
     repo_token: 033efc868120808faa564200fe1b302bac2059910ca4fcdaddbe8174179863f9

--- a/package.json
+++ b/package.json
@@ -48,10 +48,10 @@
     }
   },
   "devDependencies": {
-    "codeclimate-test-reporter": "^0.3.1",
+    "codeclimate-test-reporter": "^0.4.0",
     "eslint": "^2.4.0",
     "istanbul": "^0.4.2",
-    "mocha": "^2.4.5",
+    "mocha": "^4.0.0",
     "sinon": "^1.17.3"
   }
 }


### PR DESCRIPTION
I was notified by Snyk about the following Vulnerabilities:

- [npm:tough-cookie:20160722](https://snyk.io/vuln/npm:tough-cookie:20160722)
- [npm:tough-cookie:20170905](https://snyk.io/vuln/npm:tough-cookie:20170905)
- [npm:debug:20170905](https://snyk.io/vuln/npm:debug:20170905) - potentially breaking change
- [npm:growl:20160721](https://snyk.io/vuln/npm:growl:20160721) - potentially breaking change
- [npm:ms:20170412](https://snyk.io/vuln/npm:ms:20170412) - potentially breaking change
- [npm:minimatch:20160620](https://snyk.io/vuln/npm:minimatch:20160620) - potentially breaking change


After upgrading mocha and codeclimate-test-reporter, the tests all still pass - so hopefully nothing has been broken in the processes.
