### PR TITLE
Service file unit options

### DIFF
--- a/README.md
+++ b/README.md
@@ -305,6 +305,13 @@ You can set specific [systemd unit options](https://www.freedesktop.org/software
 }
 ```
 
+If you do not require any specific unit options Speculate will use default options:
+```
+[Unit]
+Description=My Cool API
+After=network.target nss-lookup.target
+```
+
 ### Release Number
 
 By default speculate will set the RPM release number to 1, if you want to override this you can do so by using the `--release` flag:

--- a/README.md
+++ b/README.md
@@ -289,6 +289,22 @@ If you need to set specific [systemd service options](https://www.freedesktop.or
 }
 ```
 
+#### Unit Options
+
+You can set specific [systemd unit options](https://www.freedesktop.org/software/systemd/man/systemd.unit.html) - in the `[Unit]` section of the .service file, you can specify these using the spec.unitOptions property:
+
+```json
+{
+  "spec": {
+    "unitOptions": {
+      "After": "my-cooler-api.service",
+      "Before": "my-coolest-api.service",
+      "Requires": "my-very-cool-api.service",
+    }
+  }
+}
+```
+
 ### Release Number
 
 By default speculate will set the RPM release number to 1, if you want to override this you can do so by using the `--release` flag:

--- a/lib/serviceProperties.js
+++ b/lib/serviceProperties.js
@@ -17,7 +17,8 @@ module.exports = function (pkg) {
       username: truncate(pkg.name),
       description: pkg.description,
       environment: convertToKeyValueFromSpec(pkg.spec, 'environment'),
-      serviceOptions: convertToKeyValueFromSpec(pkg.spec, 'serviceOptions')
+      serviceOptions: convertToKeyValueFromSpec(pkg.spec, 'serviceOptions'),
+      unitOptions: convertToKeyValueFromSpec(pkg.spec, 'unitOptions')
     }
   );
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "speculate",
-  "version": "1.7.4",
+  "version": "2.0.0-alpha.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2006,6 +2006,14 @@
         }
       }
     },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+      "requires": {
+        "safe-buffer": "5.1.1"
+      }
+    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
@@ -2031,14 +2039,6 @@
             "ansi-regex": "3.0.0"
           }
         }
-      }
-    },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-      "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "requires": {
-        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/templates/service.mustache
+++ b/templates/service.mustache
@@ -1,6 +1,11 @@
 [Unit]
 Description={{description}}
+{{#unitOptions}}
+{{key}}={{value}}
+{{/unitOptions}}
+{{^unitOptions}}
 After=network.target nss-lookup.target
+{{/unitOptions}}
 
 [Service]
 ExecStart=/usr/bin/npm start

--- a/test/fixtures/my-cool-api-with-unit-options.json
+++ b/test/fixtures/my-cool-api-with-unit-options.json
@@ -1,0 +1,18 @@
+{
+  "name": "my-cool-api",
+  "version": "1.1.1",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "description": "My Cool API",
+  "main": "index.js",
+  "author": "bob@example.com",
+  "license": "MIT",
+  "spec": {
+    "unitOptions": {
+      "Before": "my-cooler-api.service",
+      "After": "my-coolest-api.service",
+      "Requires": "my-coolest-api.service"
+    }
+  }
+}

--- a/test/fixtures/my-cool-api-with-unit-options.service
+++ b/test/fixtures/my-cool-api-with-unit-options.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=My Cool API
+Before=my-cooler-api.service
+After=my-coolest-api.service
+Requires=my-coolest-api.service
+
+[Service]
+ExecStart=/usr/bin/npm start
+WorkingDirectory=/usr/lib/my-cool-api
+Restart=always
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=my-cool-api
+User=my-cool-api
+Group=my-cool-api
+
+[Install]
+WantedBy=multi-user.target

--- a/test/service.js
+++ b/test/service.js
@@ -36,4 +36,12 @@ describe('service', () => {
 
     assert.equal(service, expected);
   });
+
+  it('incudes unit options from the spec.unitOptions property in the package.json', () => {
+    const pkg = require('./fixtures/my-cool-api-with-unit-options');
+    const expected = loadFixture('my-cool-api-with-unit-options.service');
+    const service = createServiceFile(pkg);
+
+    assert.equal(service, expected);
+  });
 });


### PR DESCRIPTION
Adding ability to specify Unit options for the generated `.service` file

If no options are specified it will maintain existing behaviour so not to affect existing projects. 