### PR TITLE
Do not ignore the service file in the archive

### DIFF
--- a/lib/archiver.js
+++ b/lib/archiver.js
@@ -14,8 +14,8 @@ const REQUIRED_ENTRIES = [
 function getEntries(whitelist) {
   if (whitelist.files) {
     // Extract the property from the whitelist
-    const { main, files } = whitelist;
-    const whitelistFromSections = [];
+    const { service, main, files } = whitelist;
+    const whitelistFromSections = [service];
 
     /*
      * It flattens the content of both properties (main and files) in the

--- a/lib/files.js
+++ b/lib/files.js
@@ -3,8 +3,11 @@
 const path = require('path');
 
 module.exports = {
+  serviceFileName: function (pkg) {
+    return `${pkg.name}.service`;
+  },
   serviceFile: function (root, pkg) {
-    return path.resolve(root, pkg.name + '.service');
+    return path.resolve(root, this.serviceFileName(pkg));
   },
   specsDirectory: function (root) {
     return path.resolve(root, 'SPECS');

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -40,8 +40,12 @@ function relativeToRoot(root, files) {
   });
 }
 
-function getArchiveWhitelist({ main, files }) {
-  return { main, files };
+function getArchiveWhitelist(pkg) {
+  return {
+    service: files.serviceFileName(pkg),
+    main: pkg.main,
+    files: pkg.files
+  };
 }
 
 module.exports = async (root, pkg, release, customName) => {

--- a/test/archiver.js
+++ b/test/archiver.js
@@ -78,12 +78,13 @@ describe('archiver', () => {
   });
 
   it('archives files on a whitelist if specified alongside required files', async () => {
+    const service = 'my-cool-api.service';
     const files = [
       'lib',
       'routes',
       'index.js'
     ];
-    const result = archiver.compress('/tmp/SOURCES', 'tmp.tar.gz', { files });
+    const result = archiver.compress('/tmp/SOURCES', 'tmp.tar.gz', { service, files });
     writeStream.emit('close');
 
     await result;
@@ -92,6 +93,7 @@ describe('archiver', () => {
       entries: [
         'package.json',
         'node_modules',
+        'my-cool-api.service',
         'lib',
         'routes',
         'index.js'
@@ -100,7 +102,8 @@ describe('archiver', () => {
   });
 
   it('does not include whitelist if none specified', async () => {
-    const result = archiver.compress('/tmp/SOURCES', 'tmp.tar.gz', {});
+    const service = 'my-cool-api.service';
+    const result = archiver.compress('/tmp/SOURCES', 'tmp.tar.gz', { service });
     writeStream.emit('close');
 
     await result;
@@ -111,13 +114,14 @@ describe('archiver', () => {
   });
 
   it('adds the "main" file to the archive alongside "files" if specified', async () => {
+    const service = 'my-cool-api.service';
     const main = 'server.js';
     const files = [
       'lib',
       'routes',
       'index.js'
     ];
-    const result = archiver.compress('/tmp/SOURCES', 'tmp.tar.gz', { main, files });
+    const result = archiver.compress('/tmp/SOURCES', 'tmp.tar.gz', { service, main, files });
     writeStream.emit('close');
 
     await result;
@@ -127,6 +131,7 @@ describe('archiver', () => {
       entries: [
         'package.json',
         'node_modules',
+        'my-cool-api.service',
         'server.js',
         'lib',
         'routes',
@@ -136,8 +141,9 @@ describe('archiver', () => {
   });
 
   it('archives everything if only the "main" is specified', async () => {
+    const service = 'my-cool-api.service';
     const main = 'server.js';
-    const result = archiver.compress('/tmp/SOURCES', 'tmp.tar.gz', { main });
+    const result = archiver.compress('/tmp/SOURCES', 'tmp.tar.gz', { service, main });
     writeStream.emit('close');
 
     await result;

--- a/test/generate.js
+++ b/test/generate.js
@@ -62,7 +62,8 @@ describe('generate', () => {
       '/path/to/project/SOURCES/my-cool-api.tar.gz',
       {
         files: undefined,
-        main: 'index.js'
+        main: 'index.js',
+        service: 'my-cool-api.service'
       }
     );
   });
@@ -110,7 +111,8 @@ describe('generate', () => {
       '/path/to/project/SOURCES/penguin.tar.gz',
       {
         files: undefined,
-        main: 'index.js'
+        main: 'index.js',
+        service: 'my-cool-api.service'
       }
     );
   });
@@ -127,7 +129,8 @@ describe('generate', () => {
           'lib',
           'routes',
           'index.js'
-        ]
+        ],
+        service: 'my-cool-api.service'
       }
     );
   });


### PR DESCRIPTION
Currently there's a bug when using the new `2.0.0` release which causes the service file to be ignored when archiving if a whitelist is specified. This encourages the archiver and generator to add this file if there's a whitelist present.