### PR TITLE
Replace version number hyphens with arbitrary strings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 coverage
 *.log
+.vscode

--- a/README.md
+++ b/README.md
@@ -351,3 +351,13 @@ Running rpmbuild on an npm package with a hyphen in its version number throws an
   }
 }
 ```
+
+Or you can supply a string if you want something other than a tilde:
+
+```json
+{
+  "spec": {
+    "replaceHyphens": "_"
+  }
+}
+```

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Running rpmbuild on an npm package with a hyphen in its version number throws an
 }
 ```
 
-Or you can supply a string if you want something other than a tilde:
+Or you can explicitly tell speculate to replace hyphens with tildes "~", underscores "_" or plus signs "+":
 
 ```json
 {

--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ Running rpmbuild on an npm package with a hyphen in its version number throws an
 }
 ```
 
-Or you can explicitly tell speculate to replace hyphens with tildes "~", underscores "_" or plus signs "+":
+Or you can explicitly tell speculate to replace hyphens with tildes `"~"`, underscores `"_"` or plus signs `"+"`:
 
 ```json
 {

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -31,7 +31,7 @@ function getVersionNumber({ spec, version }) {
       newVersion = version.replace(/-/g, replaceHyphens);
     } else {
       // eslint-disable-next-line no-console
-      console.warn(`replaceHyphens was given a forbidden string, so no replacement was done. Please use one of ${allowedReplacements.join('')}`);
+      throw new Error(`replaceHyphens was given a forbidden string, so no replacement was done. Please use one of ${allowedReplacements.join('')}`);
     }
   }
 

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -30,7 +30,6 @@ function getVersionNumber({ spec, version }) {
     if (allowedReplacements.includes(replaceHyphens)) {
       newVersion = version.replace(/-/g, replaceHyphens);
     } else {
-      // eslint-disable-next-line no-console
       throw new Error(`replaceHyphens was given a forbidden string, so no replacement was done. Please use one of ${allowedReplacements.join('')}`);
     }
   }

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -20,8 +20,15 @@ function getReleaseNumber(release) {
 
 function getVersionNumber({ spec, version }) {
   const replaceHyphens = getValueFromSpec(spec, 'replaceHyphens', false);
+  let newVersion;
 
-  return replaceHyphens ? version.replace(/-/g, '~') : version;
+  if (replaceHyphens === true) {
+    newVersion = version.replace(/-/g, '~');
+  } else if (typeof replaceHyphens === 'string') {
+    newVersion = version.replace(/-/g, replaceHyphens);
+  }
+
+  return newVersion || version;
 }
 
 function getValueFromSpec(spec, key, fallback) {

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -20,11 +20,13 @@ function getReleaseNumber(release) {
 
 function getVersionNumber({ spec, version }) {
   const replaceHyphens = getValueFromSpec(spec, 'replaceHyphens', false);
+  const allowedReplacements = ['~', '_', '+'];
   let newVersion;
 
   if (replaceHyphens === true) {
+    // Stay backwards compatible - previous version was true -> tilde.
     newVersion = version.replace(/-/g, '~');
-  } else if (typeof replaceHyphens === 'string') {
+  } else if (allowedReplacements.includes(replaceHyphens)) {
     newVersion = version.replace(/-/g, replaceHyphens);
   }
 

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -24,10 +24,15 @@ function getVersionNumber({ spec, version }) {
   let newVersion;
 
   if (replaceHyphens === true) {
-    // Stay backwards compatible - previous version was true -> tilde.
+    // Stay backwards compatible. Previous version was true -> tilde.
     newVersion = version.replace(/-/g, '~');
-  } else if (allowedReplacements.includes(replaceHyphens)) {
-    newVersion = version.replace(/-/g, replaceHyphens);
+  } else if (typeof replaceHyphens === 'string') {
+    if (allowedReplacements.includes(replaceHyphens)) {
+      newVersion = version.replace(/-/g, replaceHyphens);
+    } else {
+      // eslint-disable-next-line no-console
+      console.warn(`replaceHyphens was given a forbidden string, so no replacement was done. Please use one of ${allowedReplacements.join('')}`);
+    }
   }
 
   return newVersion || version;

--- a/test/fixtures/my-cool-api-with-hyphenated-version-and-override-underscore.json
+++ b/test/fixtures/my-cool-api-with-hyphenated-version-and-override-underscore.json
@@ -1,0 +1,14 @@
+{
+  "name": "my-cool-api",
+  "version": "1.1.1-pre-release-string.1",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "description": "My Cool API",
+  "main": "index.js",
+  "author": "bob@example.com",
+  "license": "MIT",
+  "spec": {
+    "replaceHyphens": "_"
+  }
+}

--- a/test/fixtures/my-cool-api-with-version-hyphens-replaced-underscores.spec
+++ b/test/fixtures/my-cool-api-with-version-hyphens-replaced-underscores.spec
@@ -1,0 +1,47 @@
+%define name my-cool-api
+%define version 1.1.1_pre_release_string.1
+%define release 1
+%define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+
+Name: %{name}
+Version: %{version}
+Release: %{release}
+Summary: my-cool-api
+
+Group: Installation Script
+License: MIT
+Source: %{name}.tar.gz
+BuildRoot: %{buildroot}
+Requires: nodejs
+BuildRequires: nodejs
+AutoReqProv: no
+
+%description
+My Cool API
+
+%prep
+%setup -q -c -n %{name}
+
+%build
+npm prune --production
+npm rebuild
+
+%pre
+getent group my-cool-api >/dev/null || groupadd -r my-cool-api
+getent passwd my-cool-api >/dev/null || useradd -r -g my-cool-api -G my-cool-api -d / -s /sbin/nologin -c "my-cool-api" my-cool-api
+
+%install
+mkdir -p %{buildroot}/usr/lib/my-cool-api
+cp -r ./ %{buildroot}/usr/lib/my-cool-api
+mkdir -p %{buildroot}/var/log/my-cool-api
+
+%post
+systemctl enable /usr/lib/my-cool-api/my-cool-api.service
+
+%clean
+rm -rf %{buildroot}
+
+%files
+%defattr(644, my-cool-api, my-cool-api, 755)
+/usr/lib/my-cool-api
+/var/log/my-cool-api

--- a/test/spec.js
+++ b/test/spec.js
@@ -112,11 +112,20 @@ describe('spec', () => {
     assert.equal(spec, expected);
   });
 
-  it('replaces hyphens in the package version number with spec.replaceHyphens if it is a string', () => {
+  it('replaces hyphens in the package version number with spec.replaceHyphens if it is a valid character', () => {
     const pkg = require('./fixtures/my-cool-api-with-hyphenated-version-and-override-underscore.json');
     const expected = loadFixture(
       'my-cool-api-with-version-hyphens-replaced-underscores.spec'
     );
+    const spec = createSpecFile(pkg);
+
+    assert.equal(spec, expected);
+  });
+
+  it('does not replace hyphens in the package version number if spec.replaceHyphens is not a valid character', () => {
+    const pkg = require('./fixtures/my-cool-api-with-hyphenated-version-and-override-underscore.json');
+    pkg.spec.replaceHyphens = 'invalid';
+    const expected = loadFixture('my-cool-api-with-hyphenated-version.spec');
     const spec = createSpecFile(pkg);
 
     assert.equal(spec, expected);

--- a/test/spec.js
+++ b/test/spec.js
@@ -104,7 +104,19 @@ describe('spec', () => {
 
   it('replaces hyphens in the package version number with tildes if spec.replaceHyphens is true in package.json', () => {
     const pkg = require('./fixtures/my-cool-api-with-hyphenated-version-and-override.json');
-    const expected = loadFixture('my-cool-api-with-version-hyphens-replaced.spec');
+    const expected = loadFixture(
+      'my-cool-api-with-version-hyphens-replaced.spec'
+    );
+    const spec = createSpecFile(pkg);
+
+    assert.equal(spec, expected);
+  });
+
+  it('replaces hyphens in the package version number with spec.replaceHyphens if it is a string', () => {
+    const pkg = require('./fixtures/my-cool-api-with-hyphenated-version-and-override-underscore.json');
+    const expected = loadFixture(
+      'my-cool-api-with-version-hyphens-replaced-underscores.spec'
+    );
     const spec = createSpecFile(pkg);
 
     assert.equal(spec, expected);

--- a/test/spec.js
+++ b/test/spec.js
@@ -122,13 +122,12 @@ describe('spec', () => {
     assert.equal(spec, expected);
   });
 
-  it('does not replace hyphens in the package version number if spec.replaceHyphens is not a valid character', () => {
+  it('errors if spec.replaceHyphens is not a valid character', () => {
     const pkg = require('./fixtures/my-cool-api-with-hyphenated-version-and-override-underscore.json');
     pkg.spec.replaceHyphens = 'invalid';
-    const expected = loadFixture('my-cool-api-with-hyphenated-version.spec');
-    const spec = createSpecFile(pkg);
+    const erroringSpecCall = createSpecFile.bind(null, pkg);
 
-    assert.equal(spec, expected);
+    assert.throws(erroringSpecCall);
   });
 
   it('does not replace hyphens in the package version number if spec.replaceHyphens is not defined in package.json', () => {


### PR DESCRIPTION
Building on top of https://github.com/bbc/speculate/pull/66.

The tilde I used in the first PR turns out to not work for my use-case, so here I suggest expanding on it to let people specify whatever they want to replace hyphens with. I've kept the behaviour that 'true' in the config results in tildes to keep it backwards compatible.

It's fiddly that rpmbuild doesn't like hyphens, and the deployment infrastructure I need to use doesn't like tildes, but oh well.