### PR TITLE
Add simple build and service overrides

### DIFF
--- a/README.md
+++ b/README.md
@@ -269,6 +269,22 @@ If you need to perform any actions after installing your package (such as moving
 }
 ```
 
+### Build Steps
+
+If you need to perform any actions during the building of your package (such as yarn install or using some other package manager) you can specify these inline using the `buildSteps` property:
+
+```json
+{
+  "spec": {
+    "buildSteps": [
+      "yarn install --production"
+    ]
+  }
+}
+```
+
+If you've specified something here it will disable the prune and rebuild steps.
+
 ### Environment variable
 
 If you need to specify environment variables during startup (NODE_ENV for example) you can specify these inline using the spec.environment property:
@@ -298,6 +314,8 @@ If you need to set specific [systemd service options](https://www.freedesktop.or
   }
 }
 ```
+
+These will overwrite the defaults for ExecStart, Restart, StandardOutput, and StandardError if you set them. Make sure to use complete and correct paths to the executable for your ExecStart overrides.
 
 #### Unit Options
 

--- a/lib/service.js
+++ b/lib/service.js
@@ -10,6 +10,5 @@ const template = handlebars.compile(templateFile);
 
 module.exports = function (pkg) {
   const serviceProperties = getServiceProperties(pkg);
-
   return template(serviceProperties);
 };

--- a/lib/serviceProperties.js
+++ b/lib/serviceProperties.js
@@ -10,6 +10,22 @@ function convertToKeyValueFromSpec(spec, prop) {
   }
 }
 
+const serviceDefaults = {
+  ExecStart: '/usr/bin/npm start',
+  Restart: 'always',
+  StandardOutput: 'syslog',
+  StandardError: 'syslog'
+};
+
+function createServiceDefaults(spec = {}) {
+  const combinedConfig = Object.assign(
+    {},
+    serviceDefaults,
+    spec.serviceOptions
+  );
+  return convertToKeyValueFromSpec({ combinedConfig }, 'combinedConfig');
+}
+
 module.exports = function (pkg) {
   return Object.assign(
     {
@@ -17,7 +33,7 @@ module.exports = function (pkg) {
       username: truncate(pkg.name),
       description: pkg.description,
       environment: convertToKeyValueFromSpec(pkg.spec, 'environment'),
-      serviceOptions: convertToKeyValueFromSpec(pkg.spec, 'serviceOptions'),
+      serviceOptions: createServiceDefaults(pkg.spec),
       unitOptions: convertToKeyValueFromSpec(pkg.spec, 'unitOptions')
     }
   );

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -58,11 +58,12 @@ function getExecutableFiles(pkg) {
 }
 
 module.exports = function (pkg, release) {
-  const serviceProperties = Object.assign(
+  const specProperties = Object.assign(
     {
       release: getReleaseNumber(release),
       requires: getValueFromSpec(pkg.spec, 'requires', []),
       buildRequires: getValueFromSpec(pkg.spec, 'buildRequires', []),
+      buildSteps: getValueFromSpec(pkg.spec, 'buildSteps'),
       postInstallCommands: getValueFromSpec(pkg.spec, 'post', []),
       nodeVersion: getValueFromSpec(pkg.spec, 'nodeVersion'),
       version: getVersionNumber(pkg),
@@ -73,6 +74,9 @@ module.exports = function (pkg, release) {
     getExecutableFiles(pkg),
     getServiceProperties(pkg)
   );
-
-  return template(serviceProperties);
+  if (specProperties.buildSteps) {
+    specProperties.prune = false;
+    specProperties.rebuild = false;
+  }
+  return template(specProperties);
 };

--- a/templates/service.hbs
+++ b/templates/service.hbs
@@ -8,20 +8,16 @@ After=network.target nss-lookup.target
 {{/unitOptions}}
 
 [Service]
-ExecStart=/usr/bin/npm start
+{{#serviceOptions}}
+{{key}}={{value}}
+{{/serviceOptions}}
 WorkingDirectory=/usr/lib/{{name}}
-Restart=always
-StandardOutput=syslog
-StandardError=syslog
 SyslogIdentifier={{name}}
 User={{username}}
 Group={{username}}
 {{#environment}}
 Environment={{key}}={{value}}
 {{/environment}}
-{{#serviceOptions}}
-{{key}}={{value}}
-{{/serviceOptions}}
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/spec.hbs
+++ b/templates/spec.hbs
@@ -35,6 +35,9 @@ npm prune --production
 {{#rebuild}}
 npm rebuild
 {{/rebuild}}
+{{#buildSteps}}
+{{{.}}}
+{{/buildSteps}}
 
 %pre
 getent group {{username}} >/dev/null || groupadd -r {{username}}

--- a/test/fixtures/my-cool-api-environment.service
+++ b/test/fixtures/my-cool-api-environment.service
@@ -4,10 +4,10 @@ After=network.target nss-lookup.target
 
 [Service]
 ExecStart=/usr/bin/npm start
-WorkingDirectory=/usr/lib/my-cool-api
 Restart=always
 StandardOutput=syslog
 StandardError=syslog
+WorkingDirectory=/usr/lib/my-cool-api
 SyslogIdentifier=my-cool-api
 User=my-cool-api
 Group=my-cool-api

--- a/test/fixtures/my-cool-api-with-service-options.service
+++ b/test/fixtures/my-cool-api-with-service-options.service
@@ -4,15 +4,15 @@ After=network.target nss-lookup.target
 
 [Service]
 ExecStart=/usr/bin/npm start
-WorkingDirectory=/usr/lib/my-cool-api
 Restart=always
 StandardOutput=syslog
 StandardError=syslog
+CPUSchedulingPriority=50
+LimitNOFILE=10000
+WorkingDirectory=/usr/lib/my-cool-api
 SyslogIdentifier=my-cool-api
 User=my-cool-api
 Group=my-cool-api
-CPUSchedulingPriority=50
-LimitNOFILE=10000
 
 [Install]
 WantedBy=multi-user.target

--- a/test/fixtures/my-cool-api-with-unit-options.service
+++ b/test/fixtures/my-cool-api-with-unit-options.service
@@ -6,10 +6,10 @@ Requires=my-coolest-api.service
 
 [Service]
 ExecStart=/usr/bin/npm start
-WorkingDirectory=/usr/lib/my-cool-api
 Restart=always
 StandardOutput=syslog
 StandardError=syslog
+WorkingDirectory=/usr/lib/my-cool-api
 SyslogIdentifier=my-cool-api
 User=my-cool-api
 Group=my-cool-api

--- a/test/fixtures/my-cool-api.service
+++ b/test/fixtures/my-cool-api.service
@@ -4,10 +4,10 @@ After=network.target nss-lookup.target
 
 [Service]
 ExecStart=/usr/bin/npm start
-WorkingDirectory=/usr/lib/my-cool-api
 Restart=always
 StandardOutput=syslog
 StandardError=syslog
+WorkingDirectory=/usr/lib/my-cool-api
 SyslogIdentifier=my-cool-api
 User=my-cool-api
 Group=my-cool-api

--- a/test/fixtures/my-super-long-long-long-long-cat-api.service
+++ b/test/fixtures/my-super-long-long-long-long-cat-api.service
@@ -4,10 +4,10 @@ After=network.target nss-lookup.target
 
 [Service]
 ExecStart=/usr/bin/npm start
-WorkingDirectory=/usr/lib/my-super-long-long-long-long-cat-api
 Restart=always
 StandardOutput=syslog
 StandardError=syslog
+WorkingDirectory=/usr/lib/my-super-long-long-long-long-cat-api
 SyslogIdentifier=my-super-long-long-long-long-cat-api
 User=my-super-long-long-long-long-cat
 Group=my-super-long-long-long-long-cat


### PR DESCRIPTION
This commit adds the ability to override some of the service config,
while maintaining our sane defaults. It also allows you to change
the build steps around to anything. This support is needed for us
to be able to install a pakcage not using npm.