### PR TITLE
Set NODE_ENV=production when running npm prune

### DIFF
--- a/templates/spec.hbs
+++ b/templates/spec.hbs
@@ -30,7 +30,9 @@ AutoReqProv: no
 
 %build
 {{#prune}}
-npm prune --production
+# Setting NODE_ENV is the same as --production or --omit=dev. Using NODE_ENV here as pruning has slightly different behaviour in newer versions.
+# See https://docs.npmjs.com/cli/v8/commands/npm-prune compared to https://docs.npmjs.com/cli/v6/commands/npm-prune
+NODE_ENV=production npm prune
 {{/prune}}
 {{#rebuild}}
 npm rebuild

--- a/test/fixtures/my-cool-api-7.spec
+++ b/test/fixtures/my-cool-api-7.spec
@@ -23,7 +23,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-no-rebuild.spec
+++ b/test/fixtures/my-cool-api-no-rebuild.spec
@@ -23,7 +23,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 
 %pre
 getent group my-cool-api >/dev/null || groupadd -r my-cool-api

--- a/test/fixtures/my-cool-api-with-buildrequires.spec
+++ b/test/fixtures/my-cool-api-with-buildrequires.spec
@@ -24,7 +24,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-with-diff-licence.spec
+++ b/test/fixtures/my-cool-api-with-diff-licence.spec
@@ -25,7 +25,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-with-executable.spec
+++ b/test/fixtures/my-cool-api-with-executable.spec
@@ -23,7 +23,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-with-hyphenated-version.spec
+++ b/test/fixtures/my-cool-api-with-hyphenated-version.spec
@@ -23,7 +23,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-with-node-version.spec
+++ b/test/fixtures/my-cool-api-with-node-version.spec
@@ -25,7 +25,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-with-post.spec
+++ b/test/fixtures/my-cool-api-with-post.spec
@@ -23,7 +23,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-with-requires-noescape.spec
+++ b/test/fixtures/my-cool-api-with-requires-noescape.spec
@@ -25,7 +25,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-with-requires.spec
+++ b/test/fixtures/my-cool-api-with-requires.spec
@@ -25,7 +25,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-with-version-hyphens-replaced-underscores.spec
+++ b/test/fixtures/my-cool-api-with-version-hyphens-replaced-underscores.spec
@@ -23,7 +23,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api-with-version-hyphens-replaced.spec
+++ b/test/fixtures/my-cool-api-with-version-hyphens-replaced.spec
@@ -23,7 +23,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 npm rebuild
 
 %pre

--- a/test/fixtures/my-cool-api.spec
+++ b/test/fixtures/my-cool-api.spec
@@ -23,7 +23,7 @@ My Cool API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 npm rebuild
 
 %pre

--- a/test/fixtures/my-super-long-long-long-long-cat-api.spec
+++ b/test/fixtures/my-super-long-long-long-long-cat-api.spec
@@ -23,7 +23,7 @@ My Super Long Long Long Long Cat API
 %setup -q -c -n %{name}
 
 %build
-npm prune --production
+NODE_ENV=production npm prune
 npm rebuild
 
 %pre


### PR DESCRIPTION
We've seen issues whereby `npm prune --production` on NPM 8 running inside mock (with no internet access) fails because its trying to resolve dev dependencies. The fix for this would be to change to `npm prune --omit=dev` which would stop trying to resolve dev dependencies. However some users of speculate use NPM 6, which does not support `--omit=dev`.

According to https://docs.npmjs.com/cli/v8/commands/npm-prune and https://docs.npmjs.com/cli/v6/commands/npm-prune, setting `NODE_ENV=production` will have the same effect as `--omit=dev` on NPM 8 and `--production` on NPM 6 respectively.