### PR TITLE
[#97] Update README: clarify nodejs embedded by default in spec

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,8 @@ If you have any build dependencies (such as `python` for `node-gyp`), instead of
 }
 ```
 
+> NOTE: given that `speculate` generates RPM spec files for Node.js projects in particular, the `nodejs` RPM dependency is already declared by default in the "spec" template. As such, you don't need to specify `nodejs` as a dependency in neither "requires" nor "buildRequires" sections, as it will result as a duplicate.
+
 ### Executables
 
 If you have scripts that need to be executable when they're installed on your target server, add them to the `executable` array. You can list both files and entire directories:


### PR DESCRIPTION
Ref: https://github.com/bbc/speculate/issues/97

## Description

Update the README to clarify that the `nodejs` dependency is already embedded by default in the "spec" template and as such, it doesn't need to be specified as a requirement or build requirement in the configuration file.