### PR TITLE
Later versions of nodejs require npm to be added explicitly

### DIFF
--- a/templates/spec.hbs
+++ b/templates/spec.hbs
@@ -18,6 +18,7 @@ Requires: nodejs{{#if nodeVersion}} {{{nodeVersion}}}{{/if}}
 Requires: {{{.}}}
 {{/requires}}
 BuildRequires: nodejs{{#if nodeVersion}} {{{nodeVersion}}}{{/if}}
+BuildRequires: npm
 {{#buildRequires}}
 BuildRequires: {{{.}}}
 {{/buildRequires}}


### PR DESCRIPTION
Later versions of nodejs don't include npm by default leading to an incomplete RPM template that subsequently fails to build. 