### PR TITLE
FIX: fix for mangling shebang

### DIFF
--- a/templates/spec.hbs
+++ b/templates/spec.hbs
@@ -3,6 +3,7 @@
 %define version {{version}}
 %define release {{release}}
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api-7.spec
+++ b/test/fixtures/my-cool-api-7.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1
 %define release 7
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api-no-prune.spec
+++ b/test/fixtures/my-cool-api-no-prune.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api-no-rebuild.spec
+++ b/test/fixtures/my-cool-api-no-rebuild.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api-with-buildrequires.spec
+++ b/test/fixtures/my-cool-api-with-buildrequires.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api-with-diff-licence.spec
+++ b/test/fixtures/my-cool-api-with-diff-licence.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api-with-executable.spec
+++ b/test/fixtures/my-cool-api-with-executable.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api-with-hyphenated-version.spec
+++ b/test/fixtures/my-cool-api-with-hyphenated-version.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1-pre-release-string.1
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api-with-node-version.spec
+++ b/test/fixtures/my-cool-api-with-node-version.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api-with-post.spec
+++ b/test/fixtures/my-cool-api-with-post.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api-with-requires-noescape.spec
+++ b/test/fixtures/my-cool-api-with-requires-noescape.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api-with-requires.spec
+++ b/test/fixtures/my-cool-api-with-requires.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api-with-version-hyphens-replaced-underscores.spec
+++ b/test/fixtures/my-cool-api-with-version-hyphens-replaced-underscores.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1_pre_release_string.1
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api-with-version-hyphens-replaced.spec
+++ b/test/fixtures/my-cool-api-with-version-hyphens-replaced.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1~pre~release~string.1
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-cool-api.spec
+++ b/test/fixtures/my-cool-api.spec
@@ -3,6 +3,7 @@
 %define version 1.1.1
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}

--- a/test/fixtures/my-super-long-long-long-long-cat-api.spec
+++ b/test/fixtures/my-super-long-long-long-long-cat-api.spec
@@ -3,6 +3,7 @@
 %define version 1.0.0
 %define release 1
 %define buildroot %(mktemp -ud %{_tmppath}/%{name}-%{version}-%{release}-XXXXXX)
+%undefine __brp_mangle_shebangs
 
 Name: %{name}
 Version: %{version}


### PR DESCRIPTION
without this line, centos8 ARM fails builds with

`*** WARNING {some dependency or file here, such as a readme} is executable but has no shebang, removing executable bit`

This one liner fixes it

h/t to this https://github.com/atom/atom/pull/21964/files 