### PR TITLE
fix: archive whitelist to support custom name

### DIFF
--- a/lib/generate.js
+++ b/lib/generate.js
@@ -59,7 +59,7 @@ module.exports = async (root, pkg, release, customName) => {
 
   const serviceFile = generateServiceFile(root, customPackage);
   const specFile = generateSpecFile(specsDirectory, customPackage, release);
-  const archiveWhitelist = getArchiveWhitelist(pkg);
+  const archiveWhitelist = getArchiveWhitelist(customPackage);
 
   await archiver.compress(root, sourcesArchive, archiveWhitelist);
 

--- a/test/generate.js
+++ b/test/generate.js
@@ -133,8 +133,12 @@ describe('generate', () => {
       '/path/to/project',
       '/path/to/project/SOURCES/penguin.tar.gz',
       {
-        files: undefined,
-        main: 'index.js',
+        main: 'server.js',
+        files: [
+          'lib',
+          'routes',
+          'index.js'
+        ],
         service: 'penguin.service'
       }
     );

--- a/test/generate.js
+++ b/test/generate.js
@@ -103,6 +103,15 @@ describe('generate', () => {
     );
   });
 
+  it('creates the spec file with a custom name if specified with white list', async () => {
+    await generate('/path/to/project', pkgWithWhitelist, 1, 'penguin');
+    sandbox.assert.calledWith(
+      fs.writeFileSync,
+      '/path/to/project/SPECS/penguin.spec',
+      sandbox.match('%define name penguin')
+    );
+  });
+
   it('creates the sources archive with a custom name if specified', async () => {
     await generate('/path/to/project', pkg, null, 'penguin');
     sandbox.assert.calledWith(
@@ -112,7 +121,21 @@ describe('generate', () => {
       {
         files: undefined,
         main: 'index.js',
-        service: 'my-cool-api.service'
+        service: 'penguin.service'
+      }
+    );
+  });
+
+  it('creates the sources archive with a custom name if specified with white list', async () => {
+    await generate('/path/to/project', pkgWithWhitelist, null, 'penguin');
+    sandbox.assert.calledWith(
+      archiver.compress,
+      '/path/to/project',
+      '/path/to/project/SOURCES/penguin.tar.gz',
+      {
+        files: undefined,
+        main: 'index.js',
+        service: 'penguin.service'
       }
     );
   });
@@ -144,8 +167,26 @@ describe('generate', () => {
     );
   });
 
+  it('creates the service file with a custom name if specified with white list', async () => {
+    await generate('/path/to/project', pkgWithWhitelist, 1, 'penguin');
+    sandbox.assert.calledWith(
+      fs.writeFileSync,
+      '/path/to/project/penguin.service',
+      sandbox.match('SyslogIdentifier=penguin')
+    );
+  });
+
   it('creates the sources archive with a custom name if specified', async () => {
     await generate('/path/to/project', pkg, null, 'penguin');
+    sandbox.assert.calledWith(
+      archiver.compress,
+      '/path/to/project',
+      '/path/to/project/SOURCES/penguin.tar.gz'
+    );
+  });
+
+  it('creates the sources archive with a custom name if specified with white list', async () => {
+    await generate('/path/to/project', pkgWithWhitelist, null, 'penguin');
     sandbox.assert.calledWith(
       archiver.compress,
       '/path/to/project',


### PR DESCRIPTION
Fixes https://github.com/bbc/speculate/issues/89

Custom name with whitelist combination was broken. An existing unit test was amended because it was wrong. New unit tests were added.