### PR TITLE
Fix: Creating a service file with a custom name falls back to the package.name when package.json has "files"

### DIFF
--- a/lib/files.js
+++ b/lib/files.js
@@ -3,11 +3,11 @@
 const path = require('path');
 
 module.exports = {
-  serviceFileName: function (pkg) {
-    return `${pkg.name}.service`;
+  serviceFileName: function (name) {
+    return `${name}.service`;
   },
   serviceFile: function (root, pkg) {
-    return path.resolve(root, this.serviceFileName(pkg));
+    return path.resolve(root, this.serviceFileName(pkg.name));
   },
   specsDirectory: function (root) {
     return path.resolve(root, 'SPECS');

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -42,7 +42,7 @@ function relativeToRoot(root, files) {
 
 function getArchiveWhitelist(pkg) {
   return {
-    service: files.serviceFileName(pkg),
+    service: files.serviceFileName(pkg.name),
     main: pkg.main,
     files: pkg.files
   };

--- a/lib/generate.js
+++ b/lib/generate.js
@@ -40,9 +40,9 @@ function relativeToRoot(root, files) {
   });
 }
 
-function getArchiveWhitelist(pkg) {
+function getArchiveWhitelist(pkg, customName) {
   return {
-    service: files.serviceFileName(pkg.name),
+    service: files.serviceFileName(customName || pkg.name),
     main: pkg.main,
     files: pkg.files
   };
@@ -59,7 +59,7 @@ module.exports = async (root, pkg, release, customName) => {
 
   const serviceFile = generateServiceFile(root, customPackage);
   const specFile = generateSpecFile(specsDirectory, customPackage, release);
-  const archiveWhitelist = getArchiveWhitelist(pkg);
+  const archiveWhitelist = getArchiveWhitelist(pkg, customName);
 
   await archiver.compress(root, sourcesArchive, archiveWhitelist);
 

--- a/test/generate.js
+++ b/test/generate.js
@@ -112,7 +112,7 @@ describe('generate', () => {
       {
         files: undefined,
         main: 'index.js',
-        service: 'my-cool-api.service'
+        service: 'penguin.service'
       }
     );
   });
@@ -131,6 +131,24 @@ describe('generate', () => {
           'index.js'
         ],
         service: 'my-cool-api.service'
+      }
+    );
+  });
+
+  it('creates the service file with a custom name if specified and "files" defined', async () => {
+    await generate('/path/to/project', pkgWithWhitelist, null, 'penguin');
+    sandbox.assert.calledWith(
+      archiver.compress,
+      '/path/to/project',
+      '/path/to/project/SOURCES/penguin.tar.gz',
+      {
+        main: 'server.js',
+        files: [
+          'lib',
+          'routes',
+          'index.js'
+        ],
+        service: 'penguin.service'
       }
     );
   });


### PR DESCRIPTION
Given we call `speculate` with `--name` argument, we see that it falls back to `package.json`'s `name` when the package.json has also `files` defined.

```
// Example package.json
{
   "name": "foo",
   "files": ['path/1', 'path/2'],
}

npx speculate --name=penguin
> Error: ENOENT: no such file or directory, lstat '/Users/.../foo.service'
```

When we don't have "files" defined in our package.json, this works as expected and use the custom name defined.