### PR TITLE
feat(service): enable node --run command for v22+

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ npm install --global speculate
 * Generates an RPM Spec file for your project
 * Creates a [systemd](https://www.freedesktop.org/wiki/Software/systemd/) service definition file
 * Supports configuration using your existing `package.json`
-* Currently supports CentOS 7
+* Currently supports CentOS 7, Rocky 8, and Rocky 9
 
 ## Usage
 
@@ -176,9 +176,9 @@ If you have only a `main` directive, speculate will assume you are using it for 
 
 ### Node versions
 
-By default, the spec file that speculate generates _isn't_ tied to a particular Node version. It simply requires the `nodejs` package. It's up to you to make the package available when you install the RPM using `yum`.
+By default, the spec file that speculate generates _isn't_ tied to a particular Node version. It simply requires the `nodejs` package. It's up to you to make the package available when you install the RPM using `yum` or `dnf`.
 
-We **strongly recommend** that you use the [Nodesource binary distributions](https://github.com/nodesource/distributions) to install a modern version of Node.js for both your RPM building environment and your target server. Follow the setup instructions for [Enterprise Linux](https://github.com/nodesource/distributions#rpm) and then run `yum install nodejs`.
+We **strongly recommend** that you use `dnf`'s AppStream repositories if available, otherwise use the [Nodesource binary distributions](https://github.com/nodesource/distributions) to install a modern version of Node.js for both your RPM building environment and your target server. Follow the setup instructions for [Enterprise Linux](https://github.com/nodesource/distributions#rpm) and then run `yum install nodejs`.
 
 If you're using multiple node repositories or a repository with multiple versions of node, you can specify an RPM version requirement with the `nodeVersion` property in your `package.json` file:
 
@@ -199,6 +199,12 @@ nodejs.x86_64                             6.2.2-1nodesource.el7.centos          
 nodejs.x86_64                             1:6.3.0-1nodesource.el7.centos        nodesource
 nodejs.x86_64                             2:6.11.0-1nodesource.el7.centos       nodesource # <- Latest but epoch of '2'
 ```
+
+#### Node 22+
+
+For more recent node versions, `node` and `npm` have split into multiple packages. If there is a requirement to support both older and newer versions of node, please add `npm` to the list of [dependencies](#dependencies).
+
+If `nodeVersion` is declared to have a minimum semantic version of 22+, then the systemd service will use Node's [run](https://nodejs.org/en/learn/command-line/run-nodejs-scripts-from-the-command-line#using-the---run-flag) flag to run the start script instead of `npm`.
 
 ### Directory Structure
 

--- a/lib/getValueFromSpec.js
+++ b/lib/getValueFromSpec.js
@@ -1,0 +1,9 @@
+'use strict';
+
+module.exports = function (spec, key, fallback) {
+  if (spec && key in spec) {
+    return spec[key];
+  }
+
+  return fallback;
+};

--- a/lib/serviceProperties.js
+++ b/lib/serviceProperties.js
@@ -18,11 +18,13 @@ function getExecFromSpec(spec) {
     return '/usr/bin/npm';
   }
 
-  if (semver.minVersion(nodeVersion).major >= 22) {
+  const nodeSemVer = nodeVersion.replace(/\d*\:/, '');
+
+  if (semver.minVersion(nodeSemVer).major >= 22) {
     return '/usr/bin/node --run';
   }
 
-  return 'usr/bin/npm';
+  return '/usr/bin/npm';
 
 }
 

--- a/lib/serviceProperties.js
+++ b/lib/serviceProperties.js
@@ -1,6 +1,8 @@
 'use strict';
 
+const semver = require('semver');
 const truncate = require('./truncate');
+const getValueFromSpec = require('./getValueFromSpec');
 
 function convertToKeyValueFromSpec(spec, prop) {
   if (spec && prop in spec) {
@@ -10,6 +12,20 @@ function convertToKeyValueFromSpec(spec, prop) {
   }
 }
 
+function getExecFromSpec(spec) {
+  const nodeVersion = getValueFromSpec(spec, 'nodeVersion');
+  if (!nodeVersion) {
+    return '/usr/bin/npm';
+  }
+
+  if (semver.minVersion(nodeVersion).major >= 22) {
+    return '/usr/bin/node --run';
+  }
+
+  return 'usr/bin/npm';
+
+}
+
 module.exports = function (pkg) {
   return Object.assign(
     {
@@ -17,6 +33,7 @@ module.exports = function (pkg) {
       username: truncate(pkg.name),
       description: pkg.description,
       environment: convertToKeyValueFromSpec(pkg.spec, 'environment'),
+      execCommand: getExecFromSpec(pkg.spec),
       serviceOptions: convertToKeyValueFromSpec(pkg.spec, 'serviceOptions'),
       unitOptions: convertToKeyValueFromSpec(pkg.spec, 'unitOptions')
     }

--- a/lib/spec.js
+++ b/lib/spec.js
@@ -4,6 +4,7 @@ const handlebars = require('handlebars');
 const fs = require('fs');
 const path = require('path');
 const getServiceProperties = require('./serviceProperties');
+const getValueFromSpec = require('./getValueFromSpec');
 
 const templateFile = fs.readFileSync(path.resolve(__dirname, '../templates/spec.hbs'), 'utf-8');
 const template = handlebars.compile(templateFile);
@@ -35,14 +36,6 @@ function getVersionNumber({ spec, version }) {
   }
 
   return newVersion || version;
-}
-
-function getValueFromSpec(spec, key, fallback) {
-  if (spec && key in spec) {
-    return spec[key];
-  }
-
-  return fallback;
 }
 
 function getExecutableFiles(pkg) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "commander": "^10.0.0",
         "handlebars": "^4.7.7",
         "rimraf": "^4.1.0",
+        "semver": "^7.7.1",
         "tar-fs": "^2.1.1"
       },
       "bin": {
@@ -2429,6 +2430,17 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
     },
+    "node_modules/semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA==",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-6.0.0.tgz",
@@ -4625,6 +4637,11 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true
+    },
+    "semver": {
+      "version": "7.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.1.tgz",
+      "integrity": "sha512-hlq8tAfn0m/61p4BVRcPzIGr6LKiMwo4VM6dGi6pt4qcRkmNzTcWq6eCEjEh+qXjkMDvPlOFFSGwQjoEa6gyMA=="
     },
     "serialize-javascript": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "commander": "^10.0.0",
     "handlebars": "^4.7.7",
     "rimraf": "^4.1.0",
+    "semver": "^7.7.1",
     "tar-fs": "^2.1.1"
   },
   "eslintConfig": {

--- a/templates/service.hbs
+++ b/templates/service.hbs
@@ -8,7 +8,7 @@ After=network.target nss-lookup.target
 {{/unitOptions}}
 
 [Service]
-ExecStart=/usr/bin/npm start
+ExecStart={{execCommand}} start
 WorkingDirectory=/usr/lib/{{name}}
 Restart=always
 StandardOutput=syslog

--- a/test/fixtures/my-new-api-epoch-v22.json
+++ b/test/fixtures/my-new-api-epoch-v22.json
@@ -1,0 +1,14 @@
+{
+  "name": "my-new-api-v22",
+  "version": "1.1.1",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "description": "My New Api v22",
+  "main": "index.js",
+  "author": "bob@example.com",
+  "license": "MIT",
+  "spec": {
+    "nodeVersion": ">= 2:22.0.0"
+  }
+}

--- a/test/fixtures/my-new-api-epoch-v22.service
+++ b/test/fixtures/my-new-api-epoch-v22.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=My New Api v22
+After=network.target nss-lookup.target
+
+[Service]
+ExecStart=/usr/bin/node --run start
+WorkingDirectory=/usr/lib/my-new-api-v22
+Restart=always
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=my-new-api-v22
+User=my-new-api-v22
+Group=my-new-api-v22
+
+[Install]
+WantedBy=multi-user.target

--- a/test/fixtures/my-new-api-v22.json
+++ b/test/fixtures/my-new-api-v22.json
@@ -1,0 +1,14 @@
+{
+  "name": "my-new-api-v22",
+  "version": "1.1.1",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "description": "My New Api v22",
+  "main": "index.js",
+  "author": "bob@example.com",
+  "license": "MIT",
+  "spec": {
+    "nodeVersion": ">= 22.0.0"
+  }
+}

--- a/test/fixtures/my-new-api-v22.service
+++ b/test/fixtures/my-new-api-v22.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=My New Api v22
+After=network.target nss-lookup.target
+
+[Service]
+ExecStart=/usr/bin/node --run start
+WorkingDirectory=/usr/lib/my-new-api-v22
+Restart=always
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=my-new-api-v22
+User=my-new-api-v22
+Group=my-new-api-v22
+
+[Install]
+WantedBy=multi-user.target

--- a/test/service.js
+++ b/test/service.js
@@ -44,4 +44,13 @@ describe('service', () => {
 
     assert.equal(service, expected);
   });
+
+  it('uses node in ExecStart when version is declared >=22', () => {
+    const pkg = require('./fixtures/my-new-api-v22');
+    const expected = loadFixture('my-new-api-v22.service');
+    const service = createServiceFile(pkg);
+
+    assert.equal(service, expected);
+  });
+
 });

--- a/test/service.js
+++ b/test/service.js
@@ -53,4 +53,12 @@ describe('service', () => {
     assert.equal(service, expected);
   });
 
+  it('uses node in ExecStart when epoch version is declared >=22', () => {
+    const pkg = require('./fixtures/my-new-api-epoch-v22');
+    const expected = loadFixture('my-new-api-epoch-v22.service');
+    const service = createServiceFile(pkg);
+
+    assert.equal(service, expected);
+  });
+
 });


### PR DESCRIPTION
# Changes

- Feat(service): use `node --run` for nodeVersion >= 22

Notes:

Added an additional dependency (`semver`) as IMO it's likely the cleanest way to conditionally set the ExecStart command.
I've implemented this as a non-breaking change as with users of `npx speculate ...` or `npx speculate@latest` would inadvertently introduce this before they're ready.

Due to the managed nature to which `execStart` has always been `/usr/bin/npm start` in the past, I see this a domain that speculate manages for the end user, rather than something configurable. This mentality has served well for multiple versions of `node` through the years.

To support `>= 22.0.0`, using `node --run` instead due to reasons outlined in the README, I'm keeping this mentality until all versions below are considered unsupported. According to their [release schedule](https://github.com/nodejs/Release#readme) this won't be until mid-2026 at the earliest. 

Once we're past that point, we can seamlessly deprecate supporting `/usr/bin/npm ...` without needing to adjust configuration in the consuming applications.