### PR TITLE
Remove safe publish command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,14 +1,12 @@
 {
   "name": "speculate",
-  "private": true,
   "version": "6.0.2",
   "description": "Automatically generates an RPM Spec file for your Node.js project",
   "main": "index.js",
   "scripts": {
     "test": "mocha && npm run lint",
     "lint": "eslint .",
-    "coverage": "nyc mocha && nyc report --reporter=html && nyc report --reporter=json-summary",
-    "publish:safe": "npx @bbc/iplayer-web-safe-publish"
+    "coverage": "nyc mocha && nyc report --reporter=html && nyc report --reporter=json-summary"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
- Removes `publish:safe` command which uses a BBC owned private package. Removing due to `speculate` being open source.
- Removes `"private": true` as  `speculate` is open source.